### PR TITLE
Skip an NLRI with originator as self.

### DIFF
--- a/server/peer.go
+++ b/server/peer.go
@@ -427,6 +427,7 @@ func (peer *Peer) handleUpdate(e *FsmMsg) ([]*table.Path, []bgp.RouteFamily, *bg
 	peer.fsm.pConf.Timers.State.UpdateRecvTime = time.Now().Unix()
 	if len(e.PathList) > 0 {
 		paths := make([]*table.Path, 0, len(e.PathList))
+		paths_adjin := make([]*table.Path, 0, len(e.PathList))
 		eor := []bgp.RouteFamily{}
 		for _, path := range e.PathList {
 			if path.IsEOR() {
@@ -437,6 +438,7 @@ func (peer *Peer) handleUpdate(e *FsmMsg) ([]*table.Path, []bgp.RouteFamily, *bg
 					"AddressFamily": family,
 				}).Debug("EOR received")
 				eor = append(eor, family)
+				paths_adjin = append(paths_adjin, path)
 				continue
 			}
 			// RFC4271 9.1.2 Phase 2: Route Selection
@@ -446,6 +448,7 @@ func (peer *Peer) handleUpdate(e *FsmMsg) ([]*table.Path, []bgp.RouteFamily, *bg
 			if aspath := path.GetAsPath(); aspath != nil {
 				if hasOwnASLoop(peer.fsm.peerInfo.LocalAS, int(peer.fsm.pConf.AsPathOptions.Config.AllowOwnAs), aspath) {
 					path.SetAsLooped(true)
+					paths_adjin = append(paths_adjin, path)
 					continue
 				}
 			}
@@ -467,8 +470,9 @@ func (peer *Peer) handleUpdate(e *FsmMsg) ([]*table.Path, []bgp.RouteFamily, *bg
 			}
 
 			paths = append(paths, path)
+			paths_adjin = append(paths_adjin, path)
 		}
-		peer.adjRibIn.Update(paths)
+		peer.adjRibIn.Update(paths_adjin)
 		for _, af := range peer.fsm.pConf.AfiSafis {
 			if msg := peer.doPrefixLimit(af.State.Family, &af.PrefixLimit.Config); msg != nil {
 				return nil, nil, msg


### PR DESCRIPTION
Also, do not install the sanity check rejected routes into adj-rib-in
This is needed because when the FSM goes into gr/llgr, we install these bad routes to rib