### PR TITLE
[CW-3751] Revert back to original multipath code handling.

### DIFF
--- a/table/destination.go
+++ b/table/destination.go
@@ -563,20 +563,11 @@ func getMultiBestPath(id string, pathList []*Path) []*Path {
 	var best *Path
 	for _, p := range pathList {
 		if !p.IsNexthopInvalid {
-			if config.ADDPATH_ALL {
-				if best == nil {
-					best = p
-					list = append(list, p)
-				} else if best.CompareMultiPath(p) == 0 {
-					list = append(list, p)
-				}
-			} else {
-				if best == nil {
-					best = p
-					list = append(list, p)
-				} else if best.Compare(p) == 0 {
-					list = append(list, p)
-				}
+			if best == nil {
+				best = p
+				list = append(list, p)
+			} else if best.Compare(p) == 0 {
+				list = append(list, p)
 			}
 		}
 	}

--- a/table/path.go
+++ b/table/path.go
@@ -1156,36 +1156,6 @@ func (lhs *Path) Compare(rhs *Path) int {
 	return int(m2 - m1)
 }
 
-func (lhs *Path) CompareMultiPath(rhs *Path) int {
-	if lhs.IsLocal() && !rhs.IsLocal() {
-		return 1
-	} else if !lhs.IsLocal() && rhs.IsLocal() {
-		return -1
-	}
-
-	if !lhs.IsIBGP() && rhs.IsIBGP() {
-		return 1
-	} else if lhs.IsIBGP() && !rhs.IsIBGP() {
-		return -1
-	}
-
-	lp1, _ := lhs.GetLocalPref()
-	lp2, _ := rhs.GetLocalPref()
-	if lp1 != lp2 {
-		return int(lp1 - lp2)
-	}
-
-	l1 := lhs.GetAsPathLen()
-	l2 := rhs.GetAsPathLen()
-	if l1 != l2 {
-		return int(l2 - l1)
-	}
-
-	o1, _ := lhs.GetOrigin()
-	o2, _ := rhs.GetOrigin()
-	return int(o2 - o1)
-}
-
 func (v *Vrf) ToGlobalPath(path *Path) error {
 	nlri := path.GetNlri()
 	switch rf := path.GetRouteFamily(); rf {


### PR DESCRIPTION
We need to back to upstream original code for multipath handling to avoid flapping.