### PR TITLE
Fix FSM bug when BGPUpdate message serialization error.

### DIFF
--- a/server/fsm.go
+++ b/server/fsm.go
@@ -1414,7 +1414,11 @@ func (h *FSMHandler) sendMessageloop(ctx context.Context, wg *sync.WaitGroup) er
 				"Data":  err,
 			}).Warn("failed to serialize")
 			fsm.bgpMessageStateUpdate(0, false)
-			return nil
+			// When serialization failed we has to close the connection and
+			// generate FSM error.
+			h.errorCh <- FSM_WRITE_FAILED
+			conn.Close()
+			return fmt.Errorf("failed to Serialize BGPUpdate")
 		}
 		if err := conn.SetWriteDeadline(time.Now().Add(time.Second * time.Duration(fsm.pConf.Timers.State.NegotiatedHoldTime))); err != nil {
 			h.errorCh <- FSM_WRITE_FAILED

--- a/server/zclient.go
+++ b/server/zclient.go
@@ -581,7 +581,9 @@ func logRouteUpdate(p *table.Path, selfRouteWithdraw bool, index int, vrf uint16
 			withdraw = "self-route withdraw"
 		}
 		id := p.GetNlri().PathLocalIdentifier()
-		fmt.Printf("vrf %d [%d] %s %s id:%d %s\n", vrf, index, pstr, nhop.String(), id, withdraw)
+		log.WithFields(log.Fields{
+			"Topic": "Zebra",
+		}).Debug("vrf %d [%d] %s %s id:%d %s", vrf, index, pstr, nhop.String(), id, withdraw)
 	}
 }
 
@@ -674,11 +676,15 @@ func (z *zebraClient) loop() {
 						selfRouteWithdraw := false
 						for _, path := range dst {
 							if path.IsLocal() {
-								fmt.Println("Make Local Path selection to withdraw event", path.GetNlri().String())
+								log.WithFields(log.Fields{
+									"Topic": "Zebra",
+								}).Debug("Make Local Path selection to withdraw event %s", path.GetNlri().String())
 								selfRouteWithdraw = true
 							}
 						}
-						fmt.Println("dst-len", len(dst), "msg.Vrf", msg.Vrf)
+						log.WithFields(log.Fields{
+							"Topic": "Zebra",
+						}).Debug("dst-len %d msg.Vrf %v", len(dst), msg.Vrf)
 						for pos, path := range dst {
 							if NlriPrefix(path.GetNlri().String()) == "0.0.0.0/0" {
 								continue
@@ -713,7 +719,9 @@ func (z *zebraClient) loop() {
 							continue
 						}
 						if path.IsLocal() {
-							fmt.Println("Make Local Path selection to withdraw event", path.GetNlri().String())
+							log.WithFields(log.Fields{
+								"Topic": "Zebra",
+							}).Debug("Make Local Path selection to withdraw event %s", path.GetNlri().String())
 							selfRouteWithdraw = true
 						}
 						vrfs := []uint16{}
@@ -762,7 +770,9 @@ func (z *zebraClient) loop() {
 						continue
 					}
 					if path.IsLocal() {
-						fmt.Println("Skipping Local Path", path.GetNlri().String())
+						log.WithFields(log.Fields{
+							"Topic": "Zebra",
+						}).Debug("Skipping Local Path %s", path.GetNlri().String())
 						continue
 					}
 					vrfs := []uint16{}


### PR DESCRIPTION
When BGPUpdate serialization failed, FSM stall and neighbor processing was stopped.  This PR fix the bug.